### PR TITLE
Changed protobuf path to github

### DIFF
--- a/passive/availability.go
+++ b/passive/availability.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"log"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/availability_test.go
+++ b/passive/availability_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/bytesperdevice.go
+++ b/passive/bytesperdevice.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	_ "github.com/bmizerany/pq"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"

--- a/passive/bytesperdevice.pb.go
+++ b/passive/bytesperdevice.pb.go
@@ -4,7 +4,7 @@
 
 package passive
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/passive/bytesperdevice_test.go
+++ b/passive/bytesperdevice_test.go
@@ -3,7 +3,7 @@ package passive
 import (
 	"fmt"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/bytesperdomain.go
+++ b/passive/bytesperdomain.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	_ "github.com/bmizerany/pq"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"

--- a/passive/bytesperdomain_test.go
+++ b/passive/bytesperdomain_test.go
@@ -3,7 +3,7 @@ package passive
 import (
 	"fmt"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/bytesperminute.go
+++ b/passive/bytesperminute.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	_ "github.com/bmizerany/pq"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"

--- a/passive/bytesperminute_test.go
+++ b/passive/bytesperminute_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/index.go
+++ b/passive/index.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/lookupsperdevice.go
+++ b/passive/lookupsperdevice.go
@@ -3,7 +3,7 @@ package passive
 import (
 	"regexp"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/lookupsperdevice_test.go
+++ b/passive/lookupsperdevice_test.go
@@ -3,7 +3,7 @@ package passive
 import (
 	"fmt"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/passive_test.go
+++ b/passive/passive_test.go
@@ -4,7 +4,7 @@ package passive_test
 //import (
 //	. "bismark/passive"
 //	"bytes"
-//	"code.google.com/p/goprotobuf/proto"
+//	"github.com/golang/protobuf/proto"
 //	"encoding/binary"
 //	"fmt"
 //	"sort"

--- a/passive/statistics.go
+++ b/passive/statistics.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"math"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/statistics.pb.go
+++ b/passive/statistics.pb.go
@@ -4,7 +4,7 @@
 
 package passive
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/passive/statistics_test.go
+++ b/passive/statistics_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/sburnett/lexicographic-tuples"
 	"github.com/sburnett/transformer"
 	"github.com/sburnett/transformer/store"

--- a/passive/trace.pb.go
+++ b/passive/trace.pb.go
@@ -4,7 +4,7 @@
 
 package passive
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/passive/trace_test.go
+++ b/passive/trace_test.go
@@ -1,7 +1,7 @@
 package passive
 
 import (
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"fmt"
 	"testing"
 )


### PR DESCRIPTION
Hi Sam,

Protobuf moved to github. On the original code I couldn't run "go get github.com/sburnett/bismark-passive-server-go". By updating the imports it should work again.

Thanks!
Michele
